### PR TITLE
feat: Add common CustomButton and CustomCard components

### DIFF
--- a/src/components/common/CustomButton.tsx
+++ b/src/components/common/CustomButton.tsx
@@ -1,11 +1,38 @@
-import React from 'react'
+import React, { ReactNode } from 'react'
 import { Button } from '../ui/button'
+import clsx from 'clsx'
 
+interface CustomButtonProps {
+  type?: 'default' | 'transparent'
+  onClick?: () => void
+  rightIcon?: ReactNode
+  leftIcon?: ReactNode
+  children: ReactNode
+  className?: string
+}
 
-const CustomButton = () => {
+const CustomButton: React.FC<CustomButtonProps> = ({
+  type = 'default',
+  onClick,
+  rightIcon,
+  leftIcon,
+  children,
+  className,
+}) => {
+  const buttonClasses = clsx(
+    'flex items-center justify-center',
+    {
+      'bg-transparent border border-primary text-primary hover:bg-primary/10': type === 'transparent',
+    },
+    className
+  )
+
   return (
-      <Button>
-      </Button>
+    <Button onClick={onClick} className={buttonClasses}>
+      {leftIcon && <span className="mr-2">{leftIcon}</span>}
+      {children}
+      {rightIcon && <span className="ml-2">{rightIcon}</span>}
+    </Button>
   )
 }
 

--- a/src/components/common/CustomCard.tsx
+++ b/src/components/common/CustomCard.tsx
@@ -1,0 +1,50 @@
+import React, { ReactNode } from 'react';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'; // Adjust path if your shadcn/ui card is elsewhere
+import clsx from 'clsx';
+
+interface CustomCardProps {
+  type?: 'default' | 'transparent';
+  children: ReactNode;
+  title?: string;
+  description?: string;
+  className?: string;
+}
+
+const CustomCard: React.FC<CustomCardProps> = ({
+  type = 'default',
+  children,
+  title,
+  description,
+  className,
+}) => {
+  const cardClasses = clsx(
+    'w-full', // Default to full width, can be overridden by className
+    {
+      // Default card style (uses shadcn card default)
+      'border rounded-lg': type === 'default',
+      // Transparent card style with glassmorphism
+      'backdrop-blur-sm bg-white/10 border border-gray-200/20 rounded-lg shadow-lg': type === 'transparent',
+    },
+    className // User-provided classes
+  );
+
+  const contentClasses = clsx(
+    'p-6',
+  );
+
+  return (
+    <Card className={cardClasses}>
+      {(title || description) && (
+        <CardHeader>
+          {title && <CardTitle>{title}</CardTitle>}
+          {description && <CardDescription>{description}</CardDescription>}
+        </CardHeader>
+      )}
+      <CardContent className={contentClasses}>
+        {children}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default CustomCard;


### PR DESCRIPTION
This pull request introduces two new reusable UI components to the `src/components/common` directory: `CustomButton` and `CustomCard`. These components aim to enhance UI consistency and reduce code duplication across the application.

**1. CustomButton (`src/components/common/CustomButton.tsx`)**

*   **Objective:** Create a reusable button component with flexible styling options and icon support.
*   **Key Features:**
    *   `type` prop: Supports `'default'` and `'transparent'` (no background, only border) styles.
    *   `onClick`: Optional click handler.
    *   `rightIcon` & `leftIcon`: Optional `ReactNode` for icons on either side.
    *   Uses `clsx` for conditional class application.
    *   Built upon the base ShadCN/UI `Button` component.
    *   Ensures icons are spaced properly using flex utilities.
    *   Allows for additional `className` passthrough for further customization.

**2. CustomCard (`src/components/common/CustomCard.tsx`)**

*   **Objective:** Create a reusable card component with different visual styles, including a glassmorphism option.
*   **Key Features:**
    *   `type` prop: Supports `'default'` and `'transparent'` (with glassmorphism effect) styles.
    *   `children`: For rendering card content.
    *   Optional `title` and `description` props for the card header.
    *   Uses Tailwind CSS classes like `backdrop-blur-sm`, `bg-white/10`, `border`, and `rounded-lg` for the glassmorphism effect on the transparent type.
    *   Ensures responsive padding defaults.
    *   Built using ShadCN/UI `Card` and its sub-components (`CardHeader`, `CardTitle`, `CardDescription`, `CardContent`).
    *   Allows for additional `className` passthrough.

**Setup Considerations:**
*   The `CustomCard` component assumes the base ShadCN/UI `Card` component (and its parts) are available in the project (e.g., via `npx shadcn@latest add card`).
*   The `CustomButton` component assumes the base ShadCN/UI `Button` is available.

These components provide foundational UI elements that can be easily customized and reused throughout the project.