### PR TITLE
Fetch and display GitHub repository stars and forks in Hero component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,15 +15,15 @@
         "lucide-react": "^0.512.0",
         "next": "15.3.3",
         "next-themes": "^0.4.6",
-        "react": "^19.0.0",
+        "react": "^19.1.0",
         "react-dom": "^19.0.0",
         "tailwind-merge": "^3.3.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
         "@tailwindcss/postcss": "^4",
-        "@types/node": "^20",
-        "@types/react": "^19",
+        "@types/node": "^20.19.0",
+        "@types/react": "^19.1.6",
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "15.3.3",
@@ -1875,13 +1875,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.17.57",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.57.tgz",
-      "integrity": "sha512-f3T4y6VU4fVQDKVqJV4Uppy8c1p/sVvS3peyqxyWnzkqXFJLRU7Y1Bl7rMS1Qe9z0v4M6McY0Fp9yBsgHJUsWQ==",
+      "version": "20.19.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.0.tgz",
+      "integrity": "sha512-hfrc+1tud1xcdVTABC2JiomZJEklMcXYNTVtZLAeqTVWD+qL5jkHKT+1lOtqDdGxt+mB53DTtiz673vfjU8D1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/react": {
@@ -6680,9 +6680,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -16,15 +16,15 @@
     "lucide-react": "^0.512.0",
     "next": "15.3.3",
     "next-themes": "^0.4.6",
-    "react": "^19.0.0",
+    "react": "^19.1.0",
     "react-dom": "^19.0.0",
     "tailwind-merge": "^3.3.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
-    "@types/node": "^20",
-    "@types/react": "^19",
+    "@types/node": "^20.19.0",
+    "@types/react": "^19.1.6",
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "15.3.3",

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -4,6 +4,8 @@ import type { FC } from 'react';
 import { ChevronRight } from 'lucide-react';
 import CustomButton from './common/CustomButton';
 import CustomCard from './common/CustomCard';
+import { useEffect, useState } from 'react';
+import { fetchRepoInfo } from '@/lib/github';
 
 interface StatItem {
   value: string;
@@ -12,20 +14,33 @@ interface StatItem {
 }
 
 const Hero: FC = () => {
+  const [stars, setStars] = useState<string>('...');
+  const [forks, setForks] = useState<string>('...');
+
+  useEffect(() => {
+    fetchRepoInfo().then(data => {
+      setStars(data.stargazers_count?.toString() ?? '0');
+      setForks(data.forks_count?.toString() ?? '0');
+    }).catch(() => {
+      setStars('N/A');
+      setForks('N/A');
+    });
+  }, []);
+
   const stats: StatItem[] = [
     {
-      value: '3',
-      label: 'Core Projects',
-      valueColor: 'text-blue-600 dark:text-blue-400'
-    },
-    {
-      value: '85+',
+      value: stars,
       label: 'GitHub Stars',
       valueColor: 'text-purple-600 dark:text-purple-400'
     },
     {
-      value: '24/7',
-      label: 'Active Monitoring',
+      value: forks,
+      label: 'GitHub Forks',
+      valueColor: 'text-blue-600 dark:text-blue-400'
+    },
+    {
+      value: '3',
+      label: 'Core Projects',
       valueColor: 'text-cyan-600 dark:text-cyan-400'
     },
   ];

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,0 +1,12 @@
+export {};
+
+export async function fetchRepoInfo() {
+  const res = await fetch('https://api.github.com/repos/etherion-tools/landing', {
+    headers: {
+      'Accept': 'application/vnd.github.v3+json',
+    },
+    // No auth token for public info; add one if you hit rate limits
+  });
+  if (!res.ok) throw new Error('Failed to fetch repo info');
+  return res.json();
+} 


### PR DESCRIPTION
This PR closes #8 

This PR implements dynamic fetching and display of the Etherion Tools landing repository’s GitHub stars and forks in the Hero section of the landing page.
Added a utility function (fetchRepoInfo) in src/lib/github.ts to retrieve repository information from the GitHub API.
Updated Hero.tsx to use this utility and display live star and fork counts instead of hardcoded values.
The stats are now always up-to-date, improving transparency and engagement for visitors.