### PR TITLE
create Community section card

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,13 @@
 import Hero from '@/components/Hero';
 import AboutSection from '@/components/AboutSection';
+import CommunitySection from '@/components/common/CommunitySection';
 
 export default function Home() {
   return (
     <main>
       <Hero />
       <AboutSection />
+      <CommunitySection />
     </main>
   );
 }

--- a/src/components/common/CommunitySection.tsx
+++ b/src/components/common/CommunitySection.tsx
@@ -1,0 +1,37 @@
+const CommunitySection = () => (
+  <section id="community" className="py-20 px-6">
+    <div className="max-w-7xl mx-auto">
+      <div className="text-center mb-16">
+        <h2 className="text-4xl md:text-5xl font-bold text-gray-900 dark:text-white mb-6">
+          Join Our <span className="bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent">Community</span>
+        </h2>
+        <p className="text-xl text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
+          Connect with fellow developers, contribute to our projects, and help shape the future of web3 tools
+        </p>
+      </div>
+    </div>
+    <div className="flex justify-center w-full">
+      <div className="backdrop-blur-lg bg-white/10 dark:bg-gray-800/10 border border-white/20 dark:border-gray-700/20 rounded-2xl p-8 text-center w-full min-h-[340px] flex flex-col justify-center" style={{ maxWidth: '96rem' }}>
+        <div className="w-16 h-16 bg-gradient-to-br from-blue-500 to-purple-600 rounded-2xl flex items-center justify-center mx-auto mb-4">
+          <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-8 h-8 text-white">
+            <path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"></path>
+            <path d="M9 18c-4.51 2-5-2-7-2"></path>
+          </svg>
+        </div>
+        <h3 className="text-xl font-bold text-gray-900 dark:text-white mb-2">GitHub</h3>
+        <p className="text-gray-600 dark:text-gray-300 mb-4">Contribute to our open-source projects and help build the future</p>
+        <div className="flex items-center justify-center text-blue-400">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-4 h-4 mr-2">
+            <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"></path>
+            <circle cx="9" cy="7" r="4"></circle>
+            <path d="M22 21v-2a4 4 0 0 0-3-3.87"></path>
+            <path d="M16 3.13a4 4 0 0 1 0 7.75"></path>
+          </svg>
+          <a href="#" className="underline hover:text-blue-500">50+ Contributors</a>
+        </div>
+      </div>
+    </div>
+  </section>
+);
+
+export default CommunitySection; 


### PR DESCRIPTION
This PR closes #6 

Refactored the Community section into a standalone component.
Made the GitHub card visually prominent and centered, with adjustable width.
Moved the card outside the constrained parent to allow full-width display.
Updated all text colors to match the specified light and dark mode requirements.
Ensured the design closely matches the provided reference image.