### PR TITLE
fix: replace img with Image component in Logo for better optimization

### DIFF
--- a/src/components/common/Logo.tsx
+++ b/src/components/common/Logo.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Link from 'next/link';
+import Image from 'next/image';
 
 type LogoProps = {
   className?: string;
@@ -9,7 +10,13 @@ export function Logo({ className = "" }: LogoProps) {
   return (
     <Link href="/" className={`flex items-center gap-3 ${className}`}>
       <div className="flex items-center justify-center w-10 h-10 rounded-md bg-indigo-600">
-        <img src="/etherion-tools-logo.svg" alt="Etherion Tools Logo" className="w-8 h-8" />
+        <Image
+          src="/etherion-tools-logo.svg"
+          alt="Etherion Tools Logo"
+          width={32}
+          height={32}
+          className="w-8 h-8"
+        />
       </div>
       <span className="text-[20px] leading-7 font-bold bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent">
         Etherion Tools


### PR DESCRIPTION
I've made the following changes:
1. Added the import for `Image` from 'next/image'
2. Replaced the `<img>` tag with Next.js's `<Image>` component

These changes will resolve the warning and provide better image optimization through Next.js's image component. The `Image` component will automatically handle:
- Image optimization
- Lazy loading
- Preventing layout shift
- Responsive image loading